### PR TITLE
fix(solvable_files): Fix quotes in sql statement of gf-pgsql case

### DIFF
--- a/solvable_files.sh
+++ b/solvable_files.sh
@@ -70,7 +70,7 @@ function correct_mtime() {
 					--command="\
 						SELECT mtime
 						FROM oc_storages JOIN oc_filecache ON oc_storages.numeric_id = oc_filecache.storage \
-						WHERE oc_storages.id='local::$data_dir/' AND oc_filecache.path='CONVERT_FROM(DECODE($base64_relative_filepath, 'base64'), 'UTF-8')'"
+						WHERE oc_storages.id='local::$data_dir/' AND oc_filecache.path=CONVERT_FROM(DECODE('$base64_relative_filepath', 'base64'), 'UTF-8')"
 			)
 		fi
 	else


### PR DESCRIPTION
In SQL single quotes must be used to surround a literal string.
The path in this case is a literal string and must be quoted.
The whole `CONVERT_FROM` statement however is not a literal string.
Therefore it should not be surrounded by single quotes.

In the case for normal users and pgsql the quotes are correct.

Resolves: #14 