### PR TITLE
add script to scan files with correct mtime in storage but not in db

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,8 @@
 # mtime correction tool kit
 
-## Limitations
-
-- Only checks for files with mtime === -3600
-- Only works with MariaDB
-
-## `unsolvable_files.sh`
-
-This script lists files that can not be fixed by the `solvable_files.sh` script. For example files on an external storage.
-
-It compares files found in the database with files found in on the server's file system and prints the diff.
-
-### Usage
-
-```shell
-./unsolvable_files.sh <data_dir> <mysql|pgsql> <db_host> <db_user> <db_pwd> <db_name>
-```
-
-### Output
-
-```shell
-$ ./unsolvable_files.sh "$PWD/data/" mysql localhost nextcloud password nextcloud
-local::/home/louis/nextcloud_external//(test).md
-local::/home/louis/nextcloud_external//test".md
-local::/home/louis/nextcloud_external//test.md
-```
-
-```shell
-$ ./unsolvable_files.sh "$PWD/data/" mysql localhost nextcloud password nextcloud | wc -l
-3
-```
-
 ## `solvable_files.sh`
 
-This script looks for problematic files on the server's file system
+This script looks for problematic files on the server's file system.
 
 The default behavior is to simply list the solvable files.
 
@@ -81,4 +50,46 @@ $ ./solvable_files.sh "$PWD/data/" mysql localhost nextcloud password nextcloud 
 ```shell
 $ ./server/mtime_scripts/solvable_files.sh "$PWD/server/data/" mysql localhost nextcloud password nextcloud list noscan | wc -l
 10
+```
+
+## `unsolvable_files.sh`
+
+This script lists files that can not be fixed by the `solvable_files.sh` script. For example files on an external storage.
+
+It compares files found in the database with files found in on the server's file system and prints the diff.
+
+### Usage
+
+```shell
+./unsolvable_files.sh <data_dir> <mysql|pgsql> <db_host> <db_user> <db_pwd> <db_name>
+```
+
+### Output
+
+```shell
+$ ./unsolvable_files.sh "$PWD/data/" mysql localhost nextcloud password nextcloud
+local::/home/louis/nextcloud_external//(test).md
+local::/home/louis/nextcloud_external//test".md
+local::/home/louis/nextcloud_external//test.md
+```
+
+```shell
+$ ./unsolvable_files.sh "$PWD/data/" mysql localhost nextcloud password nextcloud | wc -l
+3
+```
+
+## `fix_group_folders.sh`
+
+This script will simulate a scan for files located in the groupfolder's trash and version folders.
+
+### Usage
+
+```shell
+./fix_group_folders.sh <data_dir> <mysql|pgsql> <db_host> <db_user> <db_pwd> <db_name>
+```
+
+### Output
+
+```shell
+./fix_group_folders.sh "$PWD/data/" mysql localhost nextcloud password nextcloud
 ```

--- a/fix_group_folders.sh
+++ b/fix_group_folders.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -eu
+
+# Usage: ./fix_group_folders.sh <data_dir> <mysql|pgsql> <db_host> <db_user> <db_pwd> <db_name>
+
+export data_dir="$(realpath "$1")"
+export db_type="$2"
+export db_host="$3"
+export db_user="$4"
+export db_pwd="$5"
+export db_name="$6"
+
+if [ "${data_dir:0:1}" != "/" ]
+then
+	echo "data_dir must be absolute."
+	exit 1
+fi
+
+if [ "$db_type" == "mysql" ]
+then
+	for filepath in $(mysql \
+		--skip-column-names \
+		--silent \
+		--host="$db_host" \
+		--user="$db_user" \
+		--password="$db_pwd" \
+		--default-character-set=utf8 \
+		--execute="\
+			SELECT concat(oc_storages.id, oc_filecache.path) \
+			FROM oc_storages JOIN oc_filecache ON oc_storages.numeric_id = oc_filecache.storage \
+			WHERE oc_filecache.mtime < 86400 AND \
+			oc_storages.id = 'local::$data_dir/'" \
+			"$db_name" | sed -e "s/.*:://") ; do
+
+		updated_mtime=$(stat --format=%Y $filepath)
+		relative_filepath="${filepath/#$data_dir\//}"
+		base64_relative_filepath="$(printf '%s' "$relative_filepath" | base64)"
+
+		mysql \
+			--skip-column-names \
+			--silent \
+			--host="$db_host" \
+			--user="$db_user" \
+			--password="$db_pwd" \
+			--default-character-set=utf8 \
+			--execute="\
+				UPDATE oc_filecache \
+				SET mtime=$updated_mtime \
+				WHERE \
+				storage=(SELECT oc_storages.numeric_id FROM oc_storages WHERE oc_storages.id = 'local::$data_dir/') AND \
+				mtime < 86400 AND \
+				path=FROM_BASE64('$base64_relative_filepath')" \
+				"$db_name"
+	done
+elif [ "$db_type" == "pgsql" ]
+then
+	for filepath in $(psql \
+		"postgresql://$db_user:$db_pwd@$db_host/$db_name" \
+		--tuples-only \
+		--no-align \
+		-E 'UTF-8' \
+		--command="\
+			SELECT concat(oc_storages.id, oc_filecache.path) \
+			FROM oc_storages JOIN oc_filecache ON oc_storages.numeric_id = oc_filecache.storage \
+			WHERE oc_filecache.mtime < 86400 AND \
+			oc_storages.id = 'local::$data_dir/'" | sed -e "s/.*:://") ; do
+
+		updated_mtime=$(stat --format=%Y $filepath)
+		relative_filepath="${filepath/#$data_dir\//}"
+		base64_relative_filepath="$(printf '%s' "$relative_filepath" | base64)"
+
+		psql \
+			"postgresql://$db_user:$db_pwd@$db_host/$db_name" \
+			-E 'UTF-8' \
+			--command="\
+				UPDATE oc_filecache \
+				SET mtime=$updated_mtime \
+				WHERE \
+				storage=(SELECT oc_storages.numeric_id FROM oc_storages WHERE oc_storages.id = 'local::$data_dir/') AND \
+				mtime < 86400 AND \
+				path=CONVERT_FROM(DECODE('$base64_relative_filepath', 'base64'), 'UTF-8')"
+	done
+fi


### PR DESCRIPTION
should allow to update mtime in db for files that are not handled by occ
groupfolders:scan <id>

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>