### PR TITLE
Clean script

### DIFF
--- a/list_problematic_files_on_fs.sh
+++ b/list_problematic_files_on_fs.sh
@@ -6,12 +6,6 @@ set -eu
 
 export data_dir="$(realpath "$1")"
 
-if [ "${data_dir:0:1}" != "/" ]
-then
-	echo "data_dir must be absolute."
-	exit 1
-fi
-
 function check_file() {
 	filepath="$1"
 	relative_filepath="${filepath/#$data_dir\//}"

--- a/solvable_files.sh
+++ b/solvable_files.sh
@@ -66,7 +66,6 @@ function correct_mtime() {
 					"postgresql://$db_user:$db_pwd@$db_host/$db_name" \
 					--tuples-only \
 					--no-align \
-					-E 'UTF-8' \
 					--command="\
 						SELECT mtime
 						FROM oc_storages JOIN oc_filecache ON oc_storages.numeric_id = oc_filecache.storage \
@@ -97,7 +96,6 @@ function correct_mtime() {
 					"postgresql://$db_user:$db_pwd@$db_host/$db_name" \
 					--tuples-only \
 					--no-align \
-					-E 'UTF-8' \
 					--command="\
 						SELECT mtime
 						FROM oc_storages JOIN oc_filecache ON oc_storages.numeric_id = oc_filecache.storage \

--- a/solvable_files.sh
+++ b/solvable_files.sh
@@ -13,12 +13,6 @@ export db_name="$6"
 export action="${7:-list}"
 export scan_action="${8:-noscan}"
 
-if [ "${data_dir:0:1}" != "/" ]
-then
-	echo "data_dir must be absolute."
-	exit 1
-fi
-
 # 1. Return if fs mtime <= 86400
 # 2. Compute username from filepath
 # 3. Query mtime from the database with the filename and the username

--- a/solvable_files.sh
+++ b/solvable_files.sh
@@ -28,7 +28,6 @@ function correct_mtime() {
 	filepath="$1"
 	relative_filepath="${filepath/#$data_dir\//}"
 	mtime_on_fs="$(stat -c '%Y' "$filepath")"
-	data_dir_with_trailing_slash="$data_dir/"
 
 	username=$relative_filepath
 	while [ "$(dirname "$username")" != "." ]


### PR DESCRIPTION
1. Remove `-E` option on `psql` command as it is useless and wrong.
2. Remove unused variable.
3. Remove Absolute path checks as we use `realpath` now.

Fix: https://github.com/nextcloud-gmbh/mtime_fixer_tool_kit/issues/19