### PR TITLE
For the use case of the user being 'apache' not 'www-data'.

### DIFF
--- a/solvable_files.sh
+++ b/solvable_files.sh
@@ -115,7 +115,7 @@ function correct_mtime() {
 		touch -c "$filepath"
 		if [ "$scan_action" = "scan" ]
 		then
-			sudo -u www-data php ./occ files:scan --quiet --path="$relative_filepath"
+			sudo -u "$(stat -c '%U' ./occ)" php ./occ files:scan --quiet --path="$relative_filepath"
 		fi
 	fi
 }


### PR DESCRIPTION
I am adding this script because we bumped into a customer that uses 'apache' and not 'www-data'. I already sent this version to the customer via support.

Was there a reason to not pick up the user via script parameter @artonge?

Maybe we can just keep this extra script.